### PR TITLE
small fixes

### DIFF
--- a/packages/client/src/components/navigation/index.tsx
+++ b/packages/client/src/components/navigation/index.tsx
@@ -3,7 +3,7 @@ import { AppBar, List, ListItem } from '@mui/material'
 import INavigationProps from './types'
 
 const Navigation: FC<INavigationProps> = ({ children }) => (
-  <AppBar component="nav" color="transparent">
+  <AppBar component="nav" color="transparent" position="relative">
     <List>
       {Children.map(children, item => (
         <ListItem>{item}</ListItem>

--- a/packages/client/src/layouts/page-layout/styles.module.css
+++ b/packages/client/src/layouts/page-layout/styles.module.css
@@ -7,10 +7,6 @@
   font-family: 'Inter', Arial, sans-serif;
 }
 
-.header {
-  min-height: 68px;
-}
-
 .main {
   display: flex;
   flex-direction: column;

--- a/packages/client/src/themes/dark-theme.ts
+++ b/packages/client/src/themes/dark-theme.ts
@@ -82,6 +82,11 @@ const darkTheme = createTheme({
           '& .MuiFormLabel-colorPrimary': {
             color: '#ffffff',
           },
+          input: {
+            '&:-webkit-autofill, &:-webkit-autofill:focus': {
+              transition: 'background-color 0s 600000s, color 0s 600000s',
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
### Какую задачу решаем
Подправил позиционирование навигационной панели и стили header, чтобы на тех страницах, где нет хедера не занимать лишнее место. Плюс, подправил стили инпутов: при автозаполнении некрасивый бекграунд появлялся
![image](https://github.com/tsharon-byte/28_mf_teamwork_01/assets/41943627/7c5cbe05-3a38-4f75-bf62-e815391e81ac)
Стало так
![image](https://github.com/tsharon-byte/28_mf_teamwork_01/assets/41943627/eba7100b-6a1a-40ae-a302-34b0199c6eb0)
Автозаполнение без BG
![image](https://github.com/tsharon-byte/28_mf_teamwork_01/assets/41943627/9b700b79-5512-4ad7-bbe5-e37bb340aa2d)
