### PR TITLE
28-67 Исправлена ошибка в валидации пароля

### DIFF
--- a/packages/client/src/validation-rules/password-validation-rule/index.ts
+++ b/packages/client/src/validation-rules/password-validation-rule/index.ts
@@ -2,14 +2,14 @@ import ValidationRule from '../validation-rule'
 
 class PasswordValidationRule extends ValidationRule {
   error =
-    'Должно быть от 8 символов, обязательно хотя бы одна заглавная буква и цифра.'
+    'Должно быть от 8 символов, обязательно хотя бы одна заглавная буква и цифра. Использовать буквы латинского алфавита'
   checks = [
     {
       regexp: /^.{8,}$/,
       logicalNot: false,
     },
     {
-      regexp: /[A-Z]|[А-Я]+/,
+      regexp: /[A-Z]+/,
       logicalNot: false,
     },
     {

--- a/packages/client/src/validation-rules/password-validation-rule/index.ts
+++ b/packages/client/src/validation-rules/password-validation-rule/index.ts
@@ -9,7 +9,7 @@ class PasswordValidationRule extends ValidationRule {
       logicalNot: false,
     },
     {
-      regexp: /[A-Z]+/,
+      regexp: /[A-Z]|[А-Я]+/,
       logicalNot: false,
     },
     {


### PR DESCRIPTION
### Какую задачу решаем

Если ввести пароль русскими буквами происходит ошибка валидации, но в сообщении об ошибке не указано, что нельзя вводить русскими буквами.