### PR TITLE
Удалил переопределение атрибутов createdAt и updatedAt у моделей Топик и Комментарий

### DIFF
--- a/packages/server/api/v1/models/comment.ts
+++ b/packages/server/api/v1/models/comment.ts
@@ -10,6 +10,8 @@ import TopicModel from './topic'
 @Table({
   tableName: 'comments',
   modelName: 'comment',
+  createdAt: 'created_at',
+  updatedAt: 'updated_at',
 })
 class CommentModel extends Model {
   @ForeignKey(() => TopicModel)
@@ -41,20 +43,6 @@ class CommentModel extends Model {
     allowNull: false,
   })
   text!: string
-
-  @Column({
-    type: DataType.DATE,
-    allowNull: false,
-    field: 'created_at',
-    defaultValue: DataType.NOW,
-  })
-  override createdAt!: Date
-
-  @Column({
-    type: DataType.DATE,
-    field: 'updated_at',
-  })
-  override updatedAt!: Date
 }
 
 export default CommentModel

--- a/packages/server/api/v1/models/topic.ts
+++ b/packages/server/api/v1/models/topic.ts
@@ -3,6 +3,8 @@ import { DataType, Model, Table, Column } from 'sequelize-typescript'
 @Table({
   tableName: 'topics',
   modelName: 'topic',
+  createdAt: 'created_at',
+  updatedAt: 'updated_at',
 })
 class TopicModel extends Model {
   @Column({
@@ -23,20 +25,6 @@ class TopicModel extends Model {
     type: DataType.STRING(2047),
   })
   description!: string
-
-  @Column({
-    type: DataType.DATE,
-    allowNull: false,
-    field: 'created_at',
-    defaultValue: DataType.NOW,
-  })
-  override createdAt!: Date
-
-  @Column({
-    type: DataType.DATE,
-    field: 'updated_at',
-  })
-  override updatedAt!: Date
 }
 
 export default TopicModel


### PR DESCRIPTION
### Какую задачу решаем
Необходимо удалить переопределение атрибутов createdAt и updatedAt у моделей Топик и Комментарий.
