### PR TITLE
Добавил отображение уведомлений об ошибках для комментариев форума

### DIFF
--- a/packages/client/src/hooks/use-comments/index.ts
+++ b/packages/client/src/hooks/use-comments/index.ts
@@ -4,11 +4,14 @@ import { useNavigate } from 'react-router-dom'
 import { ROUTE_PATH } from '../../utils/constants'
 import commentsSelector from '../../store/slices/comments-slice/selectors/comments-selector'
 import getCommentsByIdThunk from '../../store/slices/comments-slice/thunks/get-comments-by-id-thunk'
+import useToast from '../use-toast'
 
 const useComments = () => {
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
   const { comments, loading, error } = useAppSelector(commentsSelector)
+
+  useToast(error?.message)
 
   useEffect(() => {
     if (comments.rows.length === 0) {

--- a/packages/client/src/hooks/use-toast/index.ts
+++ b/packages/client/src/hooks/use-toast/index.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react'
+import { toast } from 'react-toastify'
+
+const useToast = (message?: string) => {
+  useEffect(() => {
+    message &&
+      toast.error(message, {
+        toastId: message,
+      })
+  }, [message])
+}
+
+export default useToast

--- a/packages/client/src/hooks/use-user/index.ts
+++ b/packages/client/src/hooks/use-user/index.ts
@@ -22,11 +22,7 @@ const useUser = (toastifyError: boolean | undefined = false) => {
     dispatch(updateUserThunk(data))
   }
 
-  useToast(
-    toastifyError
-      ? error?.message
-      : ''
-  )
+  useToast(toastifyError ? error?.message : '')
 
   return {
     loading,

--- a/packages/client/src/hooks/use-user/index.ts
+++ b/packages/client/src/hooks/use-user/index.ts
@@ -1,5 +1,4 @@
 import { useEffect } from 'react'
-import { toast } from 'react-toastify'
 import { useAppDispatch, useAppSelector } from '../../store/hooks'
 import {
   retrieveUserThunk,
@@ -7,6 +6,7 @@ import {
 } from '../../store/slices/user-slice/thunks'
 import { userSelector } from '../../store/slices/user-slice/selectors'
 import { IUser } from '../../store/slices/user-slice/types'
+import useToast from '../use-toast'
 
 const useUser = (toastifyError: boolean | undefined = false) => {
   const dispatch = useAppDispatch()
@@ -22,13 +22,11 @@ const useUser = (toastifyError: boolean | undefined = false) => {
     dispatch(updateUserThunk(data))
   }
 
-  useEffect(() => {
-    toastifyError &&
-      error?.message &&
-      toast.error(error.message, {
-        toastId: error.message,
-      })
-  }, [error])
+  useToast(
+    toastifyError
+      ? error?.message
+      : ''
+  )
 
   return {
     loading,

--- a/packages/client/src/store/slices/comments-slice/index.ts
+++ b/packages/client/src/store/slices/comments-slice/index.ts
@@ -41,9 +41,11 @@ const commentsSlice = createSlice({
       )
       .addCase(createCommentsThunk.fulfilled, state => {
         state.loading = false
+        state.error = null
       })
       .addCase(createCommentsThunk.pending, state => {
         state.loading = true
+        state.error = null
       })
       .addCase(
         createCommentsThunk.rejected.type,

--- a/packages/client/src/store/slices/comments-slice/thunks/create-comments-thunk/index.ts
+++ b/packages/client/src/store/slices/comments-slice/thunks/create-comments-thunk/index.ts
@@ -1,11 +1,11 @@
 import { beInstance } from '../../../../../utils/http-transport'
 import { COMMENTS_URL } from '../../../../../constants/urls'
 import { createAsyncThunk } from '@reduxjs/toolkit'
-import { isAxiosError } from 'axios'
+import { prepareError } from '../../../../../helpers'
 
 const createCommentsThunk = createAsyncThunk(
   '/comments/createCommentsThunk',
-  async (data: Record<string, string | number | null>, thunkAPI) => {
+  async (data: Record<string, string | number | null>, { rejectWithValue }) => {
     try {
       const response = await beInstance.post(COMMENTS_URL, {
         topicId: data.id,
@@ -14,15 +14,9 @@ const createCommentsThunk = createAsyncThunk(
       })
       return response.data
     } catch (error) {
-      if (isAxiosError(error)) {
-        return thunkAPI.rejectWithValue({
-          status: error.response?.status,
-          message: error.response?.data?.reason,
-        })
-      }
-      return thunkAPI.rejectWithValue({
-        message: 'Не удалось создать комментарий',
-      })
+      return rejectWithValue(
+        prepareError(error)
+      )
     }
   }
 )

--- a/packages/client/src/store/slices/comments-slice/thunks/create-comments-thunk/index.ts
+++ b/packages/client/src/store/slices/comments-slice/thunks/create-comments-thunk/index.ts
@@ -14,9 +14,7 @@ const createCommentsThunk = createAsyncThunk(
       })
       return response.data
     } catch (error) {
-      return rejectWithValue(
-        prepareError(error)
-      )
+      return rejectWithValue(prepareError(error))
     }
   }
 )


### PR DESCRIPTION
### Какую задачу решаем
Если отправить слишком длинный комментарий, на бекенде возникнет ошибка валидации, но на фронте ничего не отобразится. Со стороны пользователя просто не будет отправляться сообщение без видимых причин.
![image](https://github.com/tsharon-byte/28_mf_teamwork_01/assets/41943627/cf73a0c5-0991-4eba-8827-df66809da092)

### Результат
Теперь появляется уведомление об ошибке
![image](https://github.com/tsharon-byte/28_mf_teamwork_01/assets/41943627/bee31ee7-dfe8-4d86-9609-ea968b8fb6bd)
