### PR TITLE
Удалено отображение ошибок в модальных окнах форума

### DIFF
--- a/packages/client/src/components/forum-components/comments-reply-modal/index.tsx
+++ b/packages/client/src/components/forum-components/comments-reply-modal/index.tsx
@@ -12,7 +12,7 @@ const CommentsReplyModal: FC<TCommentsReplyModal> = ({
   handleCloseModal,
   handleSendReply,
   handleCancel,
-  handleChangeMessage
+  handleChangeMessage,
 }) => {
   return (
     <Modal open={isOpenModal} onClose={handleCloseModal}>

--- a/packages/client/src/components/forum-components/comments-reply-modal/index.tsx
+++ b/packages/client/src/components/forum-components/comments-reply-modal/index.tsx
@@ -12,8 +12,7 @@ const CommentsReplyModal: FC<TCommentsReplyModal> = ({
   handleCloseModal,
   handleSendReply,
   handleCancel,
-  handleChangeMessage,
-  error,
+  handleChangeMessage
 }) => {
   return (
     <Modal open={isOpenModal} onClose={handleCloseModal}>
@@ -30,11 +29,6 @@ const CommentsReplyModal: FC<TCommentsReplyModal> = ({
           label="Сообщение"
           required
         />
-        {error && (
-          <Typography variant="body1" color="error">
-            {error}
-          </Typography>
-        )}
         <Box className={styles.buttons}>
           <Button
             variant="contained"

--- a/packages/client/src/components/forum-components/comments-reply-modal/types.ts
+++ b/packages/client/src/components/forum-components/comments-reply-modal/types.ts
@@ -1,5 +1,4 @@
 import { ChangeEvent, FormEvent } from 'react'
-import { Nullable } from '../../../types'
 
 export type TCommentsReplyModal = {
   isOpenModal: boolean
@@ -7,5 +6,4 @@ export type TCommentsReplyModal = {
   handleSendReply: (e: FormEvent<HTMLFormElement>) => void
   handleCancel: () => void
   handleChangeMessage: (e: ChangeEvent<HTMLInputElement>) => void
-  error: Nullable<string | undefined>
 }

--- a/packages/client/src/components/forum-components/create-topic-modal/index.tsx
+++ b/packages/client/src/components/forum-components/create-topic-modal/index.tsx
@@ -14,8 +14,7 @@ export const CreateTopicModal: FC<CreateTopicModalType> = memo(
     handleCreateChatSubmit,
     handleCancel,
     handleChangeChatName,
-    handleChangeChatDescription,
-    error,
+    handleChangeChatDescription
   }) => {
     return (
       <Modal open={isOpenModal} onClose={handleCloseModal}>
@@ -37,11 +36,6 @@ export const CreateTopicModal: FC<CreateTopicModalType> = memo(
             onChange={handleChangeChatDescription}
             label="Описание"
           />
-          {error && (
-            <Typography variant="body1" color="error">
-              {error}
-            </Typography>
-          )}
           <Box className={styles.buttons}>
             <Button
               variant="contained"

--- a/packages/client/src/components/forum-components/create-topic-modal/index.tsx
+++ b/packages/client/src/components/forum-components/create-topic-modal/index.tsx
@@ -14,7 +14,7 @@ export const CreateTopicModal: FC<CreateTopicModalType> = memo(
     handleCreateChatSubmit,
     handleCancel,
     handleChangeChatName,
-    handleChangeChatDescription
+    handleChangeChatDescription,
   }) => {
     return (
       <Modal open={isOpenModal} onClose={handleCloseModal}>

--- a/packages/client/src/components/forum-components/create-topic-modal/types.ts
+++ b/packages/client/src/components/forum-components/create-topic-modal/types.ts
@@ -1,5 +1,4 @@
 import { ChangeEvent, FormEvent } from 'react'
-import { Nullable } from '../../../types'
 
 export type CreateTopicModalType = {
   isOpenModal: boolean
@@ -8,5 +7,4 @@ export type CreateTopicModalType = {
   handleCancel: () => void
   handleChangeChatName: (e: ChangeEvent<HTMLInputElement>) => void
   handleChangeChatDescription: (e: ChangeEvent<HTMLInputElement>) => void
-  error: Nullable<string | undefined>
 }

--- a/packages/client/src/components/topic-components/topic-comment-item/index.tsx
+++ b/packages/client/src/components/topic-components/topic-comment-item/index.tsx
@@ -21,7 +21,6 @@ import { createCommentsThunk } from '../../../store/slices/comments-slice/thunks
 import getCommentsByIdThunk from '../../../store/slices/comments-slice/thunks/get-comments-by-id-thunk'
 import classNames from 'classnames'
 import TopicCommentMenu from '../TopicCommentMenu/TopicCommentMenu'
-import useComments from '../../../hooks/use-comments'
 import { IUser } from '../../../store/slices/user-slice/types'
 import { resetCommentError } from '../../../store/slices/comments-slice/actions'
 
@@ -34,7 +33,6 @@ export const TopicCommentItem = memo(
       const [message, setMessage] = useState('')
       const [user, setUser] = useState<IUser | null>(null)
 
-      const { error } = useComments()
       const { foundUsers } = useAppSelector(userSelector)
 
       const foundUser = useMemo(
@@ -147,7 +145,6 @@ export const TopicCommentItem = memo(
             handleChangeMessage={handleChangeMessage}
             handleSendReply={handleSendReply}
             handleCancel={handleCancel}
-            error={error?.message}
           />
         </>
       )

--- a/packages/client/src/pages/forum/index.tsx
+++ b/packages/client/src/pages/forum/index.tsx
@@ -26,7 +26,7 @@ import { resetChatError } from '../../store/slices/forum-slice/actions'
 
 const Forum: FC = () => {
   const dispatch = useAppDispatch()
-  const { chats, loading, error } = useChats()
+  const { chats, loading } = useChats()
   const [changedChats, setChangedChats] = useState(chats)
   const [isOpenModal, setIsOpenModal] = useState(false)
   const [chatName, setChatName] = useState('')
@@ -170,7 +170,6 @@ const Forum: FC = () => {
         handleChangeChatName={handleChangeChatName}
         handleChangeChatDescription={handleChangeChatDescription}
         handleCreateChatSubmit={handleCreateChatSubmit}
-        error={error?.message}
       />
     </>
   )


### PR DESCRIPTION
### Какую задачу решаем
Проблема заключается в том, что если, например, после отправки сообщения возникла ошибка (например, превышена длина содержимого текстового поля), то при открытии модального окна ответа, в нем отображалась эта ошибка, хотя не должна, т.к. эта ошибка не относится к отправке ответа.

### Решение
Убрал отображение ошибок в модальном окне, т.к. в целевом варианте отображение ошибок будет с помощью всплывающих окон toasts.
Сейчас можно заметить, что ошибки вообще не отображаются, т.к. отображение ошибок выполнено в связанной задаче
https://github.com/tsharon-byte/28_mf_teamwork_01/pull/78