### PR TITLE
Добавлено отображение информирующего об отсутствии результатов поиска компонента

### DIFF
--- a/packages/client/src/components/forum-components/no-one-discussion/constants.ts
+++ b/packages/client/src/components/forum-components/no-one-discussion/constants.ts
@@ -1,0 +1,15 @@
+import { ITitleVariants, IIconSizes } from './types'
+
+export const TITLE_VARIANTS: ITitleVariants = {
+    xsmall: 'h4',
+    small: 'h3',
+    middle: 'h2',
+    large: 'h1'
+}
+
+export const ICON_SIZES: IIconSizes = {
+    xsmall: 300,
+    small: 400,
+    middle: 500,
+    large: 600
+}

--- a/packages/client/src/components/forum-components/no-one-discussion/constants.ts
+++ b/packages/client/src/components/forum-components/no-one-discussion/constants.ts
@@ -1,15 +1,15 @@
 import { ITitleVariants, IIconSizes } from './types'
 
 export const TITLE_VARIANTS: ITitleVariants = {
-    xsmall: 'h4',
-    small: 'h3',
-    middle: 'h2',
-    large: 'h1'
+  xsmall: 'h4',
+  small: 'h3',
+  middle: 'h2',
+  large: 'h1',
 }
 
 export const ICON_SIZES: IIconSizes = {
-    xsmall: 300,
-    small: 400,
-    middle: 500,
-    large: 600
+  xsmall: 300,
+  small: 400,
+  middle: 500,
+  large: 600,
 }

--- a/packages/client/src/components/forum-components/no-one-discussion/index.tsx
+++ b/packages/client/src/components/forum-components/no-one-discussion/index.tsx
@@ -1,0 +1,16 @@
+import React, { FC } from 'react'
+import { Box } from '@mui/material'
+import Title from '../../title'
+import { NoDiscussionIcon } from '../../../icons'
+import styles from './styles.module.css'
+import { INoOneDiscussion } from './types'
+import { TITLE_VARIANTS, ICON_SIZES } from './constants'
+
+const NoOneDiscussion: FC<INoOneDiscussion> = ({ size = 'middle' }) => (
+    <Box className={styles.root}>
+      <Title variant={TITLE_VARIANTS[size]}>No one discussion</Title>
+      <NoDiscussionIcon size={ICON_SIZES[size]} />
+    </Box>
+)
+
+export default NoOneDiscussion

--- a/packages/client/src/components/forum-components/no-one-discussion/index.tsx
+++ b/packages/client/src/components/forum-components/no-one-discussion/index.tsx
@@ -7,10 +7,10 @@ import { INoOneDiscussion } from './types'
 import { TITLE_VARIANTS, ICON_SIZES } from './constants'
 
 const NoOneDiscussion: FC<INoOneDiscussion> = ({ size = 'middle' }) => (
-    <Box className={styles.root}>
-      <Title variant={TITLE_VARIANTS[size]}>No one discussion</Title>
-      <NoDiscussionIcon size={ICON_SIZES[size]} />
-    </Box>
+  <Box className={styles.root}>
+    <Title variant={TITLE_VARIANTS[size]}>No one discussion</Title>
+    <NoDiscussionIcon size={ICON_SIZES[size]} />
+  </Box>
 )
 
 export default NoOneDiscussion

--- a/packages/client/src/components/forum-components/no-one-discussion/styles.module.css
+++ b/packages/client/src/components/forum-components/no-one-discussion/styles.module.css
@@ -1,7 +1,7 @@
 .root {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
 }

--- a/packages/client/src/components/forum-components/no-one-discussion/styles.module.css
+++ b/packages/client/src/components/forum-components/no-one-discussion/styles.module.css
@@ -1,0 +1,7 @@
+.root {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}

--- a/packages/client/src/components/forum-components/no-one-discussion/types.ts
+++ b/packages/client/src/components/forum-components/no-one-discussion/types.ts
@@ -1,17 +1,17 @@
 export interface INoOneDiscussion {
-    size?: 'xsmall' | 'small' | 'middle' | 'large'
+  size?: 'xsmall' | 'small' | 'middle' | 'large'
 }
 
 export interface ITitleVariants {
-    xsmall: 'h4'
-    small: 'h3'
-    middle: 'h2'
-    large: 'h1'
+  xsmall: 'h4'
+  small: 'h3'
+  middle: 'h2'
+  large: 'h1'
 }
 
 export interface IIconSizes {
-    xsmall: 300
-    small: 400
-    middle: 500
-    large: 600
+  xsmall: 300
+  small: 400
+  middle: 500
+  large: 600
 }

--- a/packages/client/src/components/forum-components/no-one-discussion/types.ts
+++ b/packages/client/src/components/forum-components/no-one-discussion/types.ts
@@ -1,0 +1,17 @@
+export interface INoOneDiscussion {
+    size?: 'xsmall' | 'small' | 'middle' | 'large'
+}
+
+export interface ITitleVariants {
+    xsmall: 'h4'
+    small: 'h3'
+    middle: 'h2'
+    large: 'h1'
+}
+
+export interface IIconSizes {
+    xsmall: 300
+    small: 400
+    middle: 500
+    large: 600
+}

--- a/packages/client/src/pages/forum/index.tsx
+++ b/packages/client/src/pages/forum/index.tsx
@@ -137,25 +137,27 @@ const Forum: FC = () => {
           <CircularProgress />
         ) : (
           <>
-            {chats.rows.length === 0 && (
-              <NoOneDiscussion />
-            )}
+            {chats.rows.length === 0 && <NoOneDiscussion />}
             {chats.rows.length > 0 && (
               <>
                 <SearchAndSelectBox
                   handleSearch={handleSearch}
                   handleSelect={handleSelect}
                 />
-                {changedChats.rows.length ? changedChats.rows.map(chat => {
-                  const { id } = chat
-                  return (
-                    <TopicItem
-                      key={id}
-                      chat={chat}
-                      handleNavigate={handleNavigate}
-                    />
-                  )
-                }) : <NoOneDiscussion size="xsmall" />}
+                {changedChats.rows.length ? (
+                  changedChats.rows.map(chat => {
+                    const { id } = chat
+                    return (
+                      <TopicItem
+                        key={id}
+                        chat={chat}
+                        handleNavigate={handleNavigate}
+                      />
+                    )
+                  })
+                ) : (
+                  <NoOneDiscussion size="xsmall" />
+                )}
               </>
             )}
           </>

--- a/packages/client/src/pages/forum/index.tsx
+++ b/packages/client/src/pages/forum/index.tsx
@@ -23,6 +23,7 @@ import { SearchAndSelectBox } from '../../components/forum-components/search-and
 import { Title } from '../../components'
 import { NoDiscussionIcon } from '../../icons'
 import { resetChatError } from '../../store/slices/forum-slice/actions'
+import NoOneDiscussion from '../../components/forum-components/no-one-discussion'
 
 const Forum: FC = () => {
   const dispatch = useAppDispatch()
@@ -137,10 +138,7 @@ const Forum: FC = () => {
         ) : (
           <>
             {chats.rows.length === 0 && (
-              <>
-                <Title variant="h2">No one discussion</Title>
-                <NoDiscussionIcon size={500} />
-              </>
+              <NoOneDiscussion />
             )}
             {chats.rows.length > 0 && (
               <>
@@ -148,7 +146,7 @@ const Forum: FC = () => {
                   handleSearch={handleSearch}
                   handleSelect={handleSelect}
                 />
-                {changedChats.rows.map(chat => {
+                {changedChats.rows.length ? changedChats.rows.map(chat => {
                   const { id } = chat
                   return (
                     <TopicItem
@@ -157,7 +155,7 @@ const Forum: FC = () => {
                       handleNavigate={handleNavigate}
                     />
                   )
-                })}
+                }) : <NoOneDiscussion size="xsmall" />}
               </>
             )}
           </>


### PR DESCRIPTION
### Какую задачу решаем
Если в поиск ввести запрос, по которому нет ни одного топика, то видим такую картину
![image](https://github.com/tsharon-byte/28_mf_teamwork_01/assets/41943627/3368d1cb-8e7f-47b9-8d48-18ef4af4a994)
Необходимо добавить текст или картинку, говорящую о том, что не найдено ни одного топика, подходящего под запрос.

### Решение
Добавлено такое отображение
![image](https://github.com/tsharon-byte/28_mf_teamwork_01/assets/41943627/8c29bd56-7d6f-4882-9e12-e41a82a1eab9)
